### PR TITLE
fix for get_source

### DIFF
--- a/openmdao/core/driver.py
+++ b/openmdao/core/driver.py
@@ -464,8 +464,7 @@ class Driver(object):
 
         myoutputs = set(myoutputs)
         if recording_options['record_desvars']:
-            myoutputs.update(model.get_source(n) for n in self._designvars if model.get_source(n)
-                             is not None)
+            myoutputs.update(model.get_source(n) for n in self._designvars)
         if recording_options['record_objectives'] or recording_options['record_responses']:
             myoutputs.update(self._objs)
         if recording_options['record_constraints'] or recording_options['record_responses']:

--- a/openmdao/core/tests/test_system.py
+++ b/openmdao/core/tests/test_system.py
@@ -369,9 +369,10 @@ class TestSystem(unittest.TestCase):
 
         prob.setup()
 
-        msg = "'f' not found."
-        with assert_warning(UserWarning, msg):
+        with self.assertRaises(KeyError) as cm:
             root.get_source('f')
+
+        self.assertEqual(cm.exception.args[0], "<model> <class Group>: source for 'f' not found.")
 
     def test_list_inputs_before_final_setup(self):
         class SpeedComp(ExplicitComponent):


### PR DESCRIPTION
This fixes get_source so that it behaves the way it should.  There were a couple of test failures before when you tried to make get_source raise an exception because the promoted name dict wasn't being built correctly in the case where the top level model was a component instead of a group.